### PR TITLE
fix: fix chat completion request schema

### DIFF
--- a/taskingai/_version.py
+++ b/taskingai/_version.py
@@ -1,2 +1,2 @@
 __title__ = "taskingai"
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/taskingai/client/models/schemas/chat_completion_request.py
+++ b/taskingai/client/models/schemas/chat_completion_request.py
@@ -36,4 +36,3 @@ class ChatCompletionRequest(BaseModel):
     ] = Field(...)
     function_call: Optional[str] = Field(None)
     functions: Optional[List[ChatCompletionFunction]] = Field(None)
-    save_logs: bool = Field(False)

--- a/test/testcase/test_async/test_async_retrieval.py
+++ b/test/testcase/test_async/test_async_retrieval.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-
+import asyncio
 from taskingai.retrieval import *
 from taskingai.file import a_upload_file
 from taskingai.client.models import UploadFilePurpose
@@ -393,6 +393,8 @@ class TestChunk(Base):
     async def test_delete_chunk(self):
         # List chunks.
 
+        await asyncio.sleep(Config.sleep_time)
+
         chunks = await a_list_chunks(collection_id=self.collection_id, limit=5)
         old_nums = len(chunks)
         for index, chunk in enumerate(chunks):
@@ -404,6 +406,6 @@ class TestChunk(Base):
 
             # List chunks.
 
-            new_chunks = list_chunks(collection_id=self.collection_id)
+            new_chunks = await a_list_chunks(collection_id=self.collection_id)
             chunk_ids = [chunk.chunk_id for chunk in new_chunks]
             pytest.assume(chunk_id not in chunk_ids)

--- a/test/testcase/test_sync/conftest.py
+++ b/test/testcase/test_sync/conftest.py
@@ -36,7 +36,7 @@ def collection_id():
 @pytest.fixture(scope="session")
 def record_id(collection_id):
     res = list_records(str(collection_id))
-    record_id = res[0].record_id
+    record_id = res[-1].record_id
     return record_id
 
 

--- a/test/testcase/test_sync/test_sync_retrieval.py
+++ b/test/testcase/test_sync/test_sync_retrieval.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-
+import time
 from taskingai.retrieval import TokenTextSplitter, TextSplitter
 from taskingai.retrieval import (
     list_collections,
@@ -171,7 +171,7 @@ class TestRecord:
         res_dict = vars(res)
         assume_record_result(create_record_data, res_dict)
 
-    @pytest.mark.run(order=31)
+    @pytest.mark.run(order=32)
     @pytest.mark.parametrize("upload_file_data", upload_file_data_list[:2])
     def test_create_record_by_file(self, collection_id, upload_file_data):
         # upload file
@@ -267,7 +267,7 @@ class TestRecord:
         res_dict = vars(res)
         assume_record_result(update_record_data, res_dict)
 
-    @pytest.mark.run(order=34)
+    @pytest.mark.run(order=35)
     @pytest.mark.parametrize("upload_file_data", upload_file_data_list[2:3])
     def test_update_record_by_file(self, collection_id, record_id, upload_file_data):
         # upload file
@@ -295,7 +295,7 @@ class TestRecord:
     @pytest.mark.run(order=79)
     def test_delete_record(self, collection_id):
         # List records.
-
+        time.sleep(Config.sleep_time)
         records = list_records(collection_id=collection_id, order="desc", limit=20, after=None, before=None)
         old_nums = len(records)
         for index, record in enumerate(records):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,7 +9,7 @@ pytest-ordering==0.6
 pytest-xdist==3.6.1
 PyYAML==6.0.1
 pytest-assume==2.4.3
-pytest-asyncio==0.23.6
+pytest-asyncio==0.23.7
 asyncio==3.4.3
 pytest-tornasync>=0.6.0
 pytest-trio==0.8.0


### PR DESCRIPTION
# Pull Request

## PR Description
Remove `save_logs` field from chat completion request schema.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance enhancement
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other, please describe:

## Checklist
Before submitting this PR, please make sure:
- [x] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md) guidelines.
- [x] I have tested my changes locally to ensure they are effective.
- [x] I have updated the necessary documentation (if applicable).
